### PR TITLE
Build ordering fix

### DIFF
--- a/Artillery/Source/ArtilleryRuntime/Private/FArtilleryBusyWorker.cpp
+++ b/Artillery/Source/ArtilleryRuntime/Private/FArtilleryBusyWorker.cpp
@@ -321,10 +321,10 @@ uint32 FArtilleryBusyWorker::Run()
 	PowerThrottling.StateMask = 0;
 	SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL);
 
-	SetProcessInformation(GetCurrentProcess(), 
-						  ProcessPowerThrottling, 
-						  &PowerThrottling,
-						  sizeof(PowerThrottling));
+	// SetProcessInformation(GetCurrentProcess(), 
+	// 					  ProcessPowerThrottling, 
+	// 					  &PowerThrottling,
+	// 					  sizeof(PowerThrottling));
 	
 	//we can now start the sim. we latch only on the apply step.
 	StartTicklitesSim->Trigger();

--- a/Artillery/Source/ArtilleryRuntime/Public/BasicTypes/RequestRouterTypes.h
+++ b/Artillery/Source/ArtilleryRuntime/Public/BasicTypes/RequestRouterTypes.h
@@ -54,7 +54,7 @@ struct ARTILLERYRUNTIME_API FRequestThing
 	FVector ThingVector2;
 	FVector ThingVector3;
 	FRotator ThingRotator;
-	FARelatedBy Relationship;
+	Arty::FARelatedBy Relationship;
 	int TicksDuration = -1;
 	bool ActivateIfPossible = true;
 	bool CanExpire = true;

--- a/Artillery/Source/ArtilleryRuntime/Public/Systems/NeedA.h
+++ b/Artillery/Source/ArtilleryRuntime/Public/Systems/NeedA.h
@@ -1,7 +1,7 @@
 ﻿#pragma once
 
 #include "CoreMinimal.h"
-#include "ArtilleryDispatch.h"
+#include "AtomicTagArray.h"
 #include "EAttributes.h"
 #include "EPhysicsLayer.h"
 #include "GameFramework/Actor.h"

--- a/Barrage/Source/Barrage/Public/IsolatedJoltIncludes.h
+++ b/Barrage/Source/Barrage/Public/IsolatedJoltIncludes.h
@@ -33,6 +33,9 @@ PRAGMA_PUSH_PLATFORM_DEFAULT_PACKING
 #include "Jolt/ConfigurationString.h"
 #include "libcuckoo/cuckoohash_map.hh"
 
+struct FSkeletonKey;
+struct FBarrageKey;
+
 typedef libcuckoo::cuckoohash_map<FSkeletonKey, FBarrageKey> KeyToKey;
 
 typedef libcuckoo::cuckoohash_map<uint64_t, JPH::Ref<JPH::Shape>> BoundsToShape;

--- a/Thistle/Source/ThistleRuntime/Private/ThistleDispatch.cpp
+++ b/Thistle/Source/ThistleRuntime/Private/ThistleDispatch.cpp
@@ -1,8 +1,8 @@
 // Fill out your copyright notice in the Description page of Project Settings.
 
-
 #include "ThistleDispatch.h"
 
+#include "ArtilleryBPLibs.h"
 #include "ThistleBehavioralist.h"
 
 bool UThistleDispatch::RegistrationImplementation()

--- a/Thistle/Source/ThistleRuntime/Private/ThistleInject.cpp
+++ b/Thistle/Source/ThistleRuntime/Private/ThistleInject.cpp
@@ -1,6 +1,8 @@
 // Fill out your copyright notice in the Description page of Project Settings.
 
 #include "ThistleInject.h"
+
+#include "ArtilleryBPLibs.h"
 #include "ArtilleryDispatch.h"
 #include "UFireControlMachine.h"
 


### PR DESCRIPTION
Fixes a couple of build ordering issues to partially resolve #2.

Still getting an error building on my new test empty project for `unrecognized flag 'archSSE2' in 'p2'`, tossing that one over to @JKurzer.