### PR TITLE
Fix syntax error in PackingSystemShim.h

### DIFF
--- a/Cabling/Source/Cabling/Public/PackingSystemShim.h
+++ b/Cabling/Source/Cabling/Public/PackingSystemShim.h
@@ -102,7 +102,7 @@ template <class T> class TagPack16 :Packable16
 {
 	Bigby* PackImpl() override
 	{
-		return T.PackImpl();
+		return T::PackImpl();
 	};
 };
 
@@ -110,6 +110,6 @@ template <class T> class TagPack8 :Packable8
 {
 	uint64_t* PackImpl() override
 	{
-		return T.PackImpl();
+		return T::PackImpl();
 	}
 };

--- a/Cabling/Source/Cabling/Public/PackingSystemShim.h
+++ b/Cabling/Source/Cabling/Public/PackingSystemShim.h
@@ -97,19 +97,3 @@ public:
 
 	virtual Bigby* PackImpl() = 0;
 };
-
-template <class T> class TagPack16 :Packable16
-{
-	Bigby* PackImpl() override
-	{
-		return T::PackImpl();
-	};
-};
-
-template <class T> class TagPack8 :Packable8
-{
-	uint64_t* PackImpl() override
-	{
-		return T::PackImpl();
-	}
-};


### PR DESCRIPTION
Cloning the repo into my Plugins folder (git clone <repo> .) and building yields the following syntax errors:

```
0>PackingSystemShim.h(105): Error C3878 : syntax error: unexpected token '.' following 'simple-type-specifier'
0>PackingSystemShim.h(105): Reference  : missing one of: '(' '{' ?
0>PackingSystemShim.h(105): Reference  : the template instantiation context (the oldest one first) is
0>PackingSystemShim.h(101): Reference  : while compiling class template 'TagPack16'
0>PackingSystemShim.h(105): Error C3878 : syntax error: unexpected token '.' following 'expression'
0>PackingSystemShim.h(105): Error C2760 : syntax error: ')' was unexpected here; expected ';'
0>PackingSystemShim.h(105): Error C3878 : syntax error: unexpected token ')' following 'jump-statement'
0>PackingSystemShim.h(113): Error C3878 : syntax error: unexpected token '.' following 'simple-type-specifier'
0>PackingSystemShim.h(113): Reference  : missing one of: '(' '{' ?
0>PackingSystemShim.h(113): Reference  : the template instantiation context (the oldest one first) is
0>PackingSystemShim.h(109): Reference  : while compiling class template 'TagPack8'
0>PackingSystemShim.h(113): Error C3878 : syntax error: unexpected token '.' following 'expression'
0>PackingSystemShim.h(113): Error C2760 : syntax error: ')' was unexpected here; expected ';'
0>PackingSystemShim.h(113): Error C3878 : syntax error: unexpected token ')' following 'jump-statement'
```

The offending code is the following:

```cpp
template <class T> class TagPack16 :Packable16
{
	Bigby* PackImpl() override
	{
		return T.PackImpl();
	};
};

template <class T> class TagPack8 :Packable8
{
	uint64_t* PackImpl() override
	{
		return T.PackImpl();
	}
};
```

which tries to access PackImpl as a member of an instance of T. This PR changes this to `T::PackImpl()` which functionally can't be correct, but it at least allows the project to compile and doesn't break anything since there are no usages of TagPack8<T> and TagPack16<T>.